### PR TITLE
change to vape lib - fix gui name

### DIFF
--- a/vapelib.lua
+++ b/vapelib.lua
@@ -7,11 +7,6 @@ local Mouse = LocalPlayer:GetMouse()
 local PresetColor = Color3.fromRGB(44, 120, 224)
 local CloseBind = Enum.KeyCode.RightControl
 
-local ui = Instance.new("ScreenGui")
-ui.Name = "mXMtjKSitpp"
-ui.Parent = game.CoreGui
-ui.ZIndexBehavior = Enum.ZIndexBehavior.Sibling
-
 coroutine.wrap(
     function()
         while wait() do
@@ -90,7 +85,10 @@ function lib:Window(text, preset, closebind)
         game.CoreGui[text]:Destroy()
     end
     
-    ui.Name = text
+    local ui = Instance.new("ScreenGui")
+    ui.Name = "mXMtjKSitpp"
+    ui.Parent = game.CoreGui
+    ui.ZIndexBehavior = Enum.ZIndexBehavior.Sibling
 
     CloseBind = closebind or Enum.KeyCode.RightControl
     PresetColor = preset or Color3.fromRGB(44, 120, 224)


### PR DESCRIPTION
line 93 cancels out line 11 and this pull requests changes it. when you execute it will end up being named "ui" instead of the jumbled letters in original file.